### PR TITLE
Make generated preference class nonfinal

### DIFF
--- a/spg-processor/src/main/java/ru/noties/spg/processor/writer/SPGPreferenceWriter.java
+++ b/spg-processor/src/main/java/ru/noties/spg/processor/writer/SPGPreferenceWriter.java
@@ -33,7 +33,7 @@ public class SPGPreferenceWriter implements ru.noties.spg.processor.Logger {
             "// The description for this preference was taken from: %s\n" +
             "// Do not modify this file\n\n";
 
-    private static final String CLASS_STATEMENT_PATTERN = "public final class %s implements SPGPreferenceObject {\n\n";
+    private static final String CLASS_STATEMENT_PATTERN = "public class %s implements SPGPreferenceObject {\n\n";
 
     private static final String CONST_PREF_NAME = "PREFERENCE_NAME";
     private static final String CONST_PREF_MODE = "PREFERENCE_MODE";


### PR DESCRIPTION
I want to be able to do something like this:

```
public final class Config extends ConfigInnerPreference {

    public Config(Context context) {
        super(context);
    }
    
    public boolean isUserLoggedIn() {
        String token = getToken();
        return token != null && token.length() > 0;
    }

    @SPGPreference
    private static class ConfigInner {
        String token;
    }
}
```

but it is not possible because generated class is final. Could we make it nonfinal? 