### PR TITLE
Skip classes static members when parsing classes

### DIFF
--- a/spg-processor/src/main/java/ru/noties/spg/processor/data/SPGPreferenceParser.java
+++ b/spg-processor/src/main/java/ru/noties/spg/processor/data/SPGPreferenceParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeMirror;
@@ -98,6 +99,10 @@ public class SPGPreferenceParser implements ru.noties.spg.processor.Logger {
     private List<KeyHolder> parseKeys(List<? extends Element> enclosed) {
         final List<KeyHolder> keyHolders = new ArrayList<>();
         for (Element e: enclosed) {
+
+            if (e.getModifiers().contains(Modifier.STATIC)) {
+                continue;
+            }
 
             final ru.noties.spg.anno.SPGKey key = e.getAnnotation(ru.noties.spg.anno.SPGKey.class);
 


### PR DESCRIPTION
Some classes contain static methods. For example, a class that implements `Parcelable` interface will have a static member named `CREATOR`. SPG Processor will cause some problems when processing them, one of the problems is that, when getting `keyType` in `ParseKeys` method of `SPGPreferenceParser` class, it always returned null, this causes the condition of line 138 to be true and returns null directly, and finally causes `NullPointerException`.